### PR TITLE
Update role for network url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,13 +3,11 @@
 
 NODE_RPC_PORT: 8732
 
-tezos_docker_image: tezos/tezos:v9.0
+tezos_docker_image: tezos/tezos:v8.2
 deployment_name: "{{ tezos_network }}"
 
 node_data_dir: "/srv/tezos/{{ tezos_network }}_node"
 client_data_dir: "/srv/tezos/{{ tezos_network }}_client"
-
-node_rpc_url: "http://{{ deployment_name }}_node:{{ RPC_PORT_INTERNAL }}"
 
 # The port that the Tezos RPC process listens on internally
 RPC_PORT_INTERNAL: 8732

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,13 @@
 
 NODE_RPC_PORT: 8732
 
-tezos_docker_image: tezos/tezos:v8.2
+tezos_docker_image: tezos/tezos:v9.0
+deployment_name: "{{ tezos_network }}"
 
 node_data_dir: "/srv/tezos/{{ tezos_network }}_node"
 client_data_dir: "/srv/tezos/{{ tezos_network }}_client"
 
-node_rpc_url: "http://{{ tezos_network }}_node:{{ RPC_PORT_INTERNAL }}"
+node_rpc_url: "http://{{ deployment_name }}_node:{{ RPC_PORT_INTERNAL }}"
 
 # The port that the Tezos RPC process listens on internally
 RPC_PORT_INTERNAL: 8732

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,22 @@
 
 # tasks file for roles/tezos_baker
 
+- name: change tezos_network variable
+  set_fact:
+    network_name: "{{ tezos_network | regex_search('([^/]*)$') }}"
+  when: '"http" in tezos_network'
+
+- name: change node and client directory names
+  set_fact:
+    node_data_dir: "/srv/tezos/{{ network_name }}_node"
+    client_data_dir: "/srv/tezos/{{ network_name }}_client"
+    node_rpc_url: "{% if node_rpc_url is defined %}{{ node_rpc_url }}{% else %}http://{{ network_name }}_node:{{ RPC_PORT_INTERNAL }}{% endif %}"
+  when: network_name is defined
+
 - name: Tezos baker container
   ignore_errors: yes
   docker_container:
-    name: "{{ deployment_name }}_baker_{{ item }}"
+    name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}_baker_{{ item }}"
     image: "{{ tezos_docker_image }}"
     state: started
     recreate: yes
@@ -13,7 +25,7 @@
     restart_policy: always
     pull: yes
     networks:
-      - name: "{{ deployment_name }}"
+      - name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}"
     entrypoint: >
       tezos-baker-{{ item }} --chain main --base-dir "/home/tezos/.tezos-client"
       --endpoint "{{ node_rpc_url }}"
@@ -26,7 +38,7 @@
 - name: Tezos endorser container
   ignore_errors: yes
   docker_container:
-    name: "{{ deployment_name }}_endorser_{{ item }}"
+    name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}_endorser_{{ item }}"
     image: "{{ tezos_docker_image }}"
     state: started
     recreate: yes
@@ -34,7 +46,7 @@
     restart_policy: always
     pull: yes
     networks:
-      - name: "{{ deployment_name }}"
+      - name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}"
     entrypoint: >
       tezos-endorser-{{ item }}  --chain main --base-dir "/home/tezos/.tezos-client"
       --endpoint "{{ node_rpc_url }}"
@@ -46,7 +58,7 @@
 - name: Tezos accuser container
   ignore_errors: yes
   docker_container:
-    name: "{{ deployment_name }}_accuser_{{ item }}"
+    name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}_accuser_{{ item }}"
     image: "{{ tezos_docker_image }}"
     state: started
     recreate: yes
@@ -54,7 +66,7 @@
     restart_policy: always
     pull: yes
     networks:
-      - name: "{{ deployment_name }}"
+      - name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}"
     entrypoint: >
       tezos-accuser-{{ item }} --chain main --base-dir "/home/tezos/.tezos-client"
       --endpoint "{{ node_rpc_url }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: change tezos_network variable
   set_fact:
     network_name: "{{ tezos_network | regex_search('([^/]*)$') }}"
-  when: '"http" in tezos_network'
+  when: tezos_network is regex("((http|https)\:\/\/)?[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*")
 
 - name: change node and client directory names
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Tezos baker container
   ignore_errors: yes
   docker_container:
-    name: "{{ tezos_network }}_baker_{{ item }}"
+    name: "{{ deployment_name }}_baker_{{ item }}"
     image: "{{ tezos_docker_image }}"
     state: started
     recreate: yes
@@ -13,7 +13,7 @@
     restart_policy: always
     pull: yes
     networks:
-      - name: "{{ tezos_network }}"
+      - name: "{{ deployment_name }}"
     entrypoint: >
       tezos-baker-{{ item }} --chain main --base-dir "/home/tezos/.tezos-client"
       --endpoint "{{ node_rpc_url }}"
@@ -26,7 +26,7 @@
 - name: Tezos endorser container
   ignore_errors: yes
   docker_container:
-    name: "{{ tezos_network }}_endorser_{{ item }}"
+    name: "{{ deployment_name }}_endorser_{{ item }}"
     image: "{{ tezos_docker_image }}"
     state: started
     recreate: yes
@@ -34,7 +34,7 @@
     restart_policy: always
     pull: yes
     networks:
-      - name: "{{ tezos_network }}"
+      - name: "{{ deployment_name }}"
     entrypoint: >
       tezos-endorser-{{ item }}  --chain main --base-dir "/home/tezos/.tezos-client"
       --endpoint "{{ node_rpc_url }}"
@@ -46,7 +46,7 @@
 - name: Tezos accuser container
   ignore_errors: yes
   docker_container:
-    name: "{{ tezos_network }}_accuser_{{ item }}"
+    name: "{{ deployment_name }}_accuser_{{ item }}"
     image: "{{ tezos_docker_image }}"
     state: started
     recreate: yes
@@ -54,7 +54,7 @@
     restart_policy: always
     pull: yes
     networks:
-      - name: "{{ tezos_network }}"
+      - name: "{{ deployment_name }}"
     entrypoint: >
       tezos-accuser-{{ item }} --chain main --base-dir "/home/tezos/.tezos-client"
       --endpoint "{{ node_rpc_url }}"


### PR DESCRIPTION
This update will allow the role to take a URL value for the tezos_network variable. If the value of `tezos_network` is a URL then a new variable is set called `network_name`. The value of `network_name` will be the string after the last `/` in the URL.  This new variable will be used for naming directories, configuring the `node_rpc_url` variable, and naming the docker container. The default value `node_rpc_url` is no longer set in the `defaults.yml` file but is now set in the playbook at runtime. The value of `tezos_network` (In this case a URL) will be used to start the docker container with the `--network` flag.